### PR TITLE
ci: fix extension in workspace that do not have esbuild installed

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/extension.yml"
     branches:
       - main
+      - fix/extension-publishing
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -118,7 +119,7 @@ jobs:
       - name: Install with workspace-less
         working-directory: ./packages/vscode
         run: |
-          pnpm i --ignore-scripts --ignore-workspace
+          pnpm i --ignore-scripts --ignore-workspace --shamefully-hoist --force
         env:
           npm_config_arch: ${{ matrix.npm_config_arch }}
           NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
I'm using github CI action runners. I have a local package using npm. When I use `npm i` locally, everything is fine even tho it's a bit slow. But when using `npm i` in the github actions, the installation process hangs for 25mins then crash because out of memory.

Running `npm i` locally generates a package-lock.json which then make the further `npm i` runs much faster. But that package-lock.json is now aware that I'm using a mac m1 and will not fit github runner when ran from a windows or linux environement, what do I do ? 

I thought of using `npm ci` on the runner to make it skip a few steps and maybe it would not crash, but it cant work because it relies on the package-lock.json which is OS-specific

here we are.